### PR TITLE
Added 'color' command to the terminal.

### DIFF
--- a/components/apps/Terminal/colorArgs.json
+++ b/components/apps/Terminal/colorArgs.json
@@ -1,0 +1,18 @@
+{
+  "0": { "color_code": "\u001b[30m", "color_name": "Black" },
+  "1": { "color_code": "\u001b[34m", "color_name": "Blue" },
+  "2": { "color_code": "\u001b[32m", "color_name": "Green" },
+  "3": { "color_code": "\u001b[36m", "color_name": "Aqua" },
+  "4": { "color_code": "\u001b[31m", "color_name": "Red" },
+  "5": { "color_code": "\u001b[35m", "color_name": "Purple" },
+  "6": { "color_code": "\u001b[33m", "color_name": "Yellow" },
+  "7": { "color_code": "\u001b[37m", "color_name": "White" },
+  "8": { "color_code": "\u001b[38;5;245m", "color_name": "Gray" },
+  "9": { "color_code": "\u001b[94m", "color_name": "Light Blue" },
+  "A": { "color_code": "\u001b[92m", "color_name": "Light Green" },
+  "B": { "color_code": "\u001b[96m", "color_name": "Light Aqua" },
+  "C": { "color_code": "\u001b[91m", "color_name": "Light Red" },
+  "D": { "color_code": "\u001b[95m", "color_name": "Light Purple" },
+  "E": { "color_code": "\u001b[93m", "color_name": "Light Yellow" },
+  "F": { "color_code": "\u001b[97m", "color_name": "Bright White" }
+}

--- a/components/apps/Terminal/functions.ts
+++ b/components/apps/Terminal/functions.ts
@@ -25,6 +25,7 @@ export const help = (
 export const commands: Record<string, string> = {
   cd: "Changes the current directory.",
   clear: "Clears the screen.",
+  color: "Specifies color attribute of console output.",
   copy: "Copies a file to another location.",
   date: "Displays the date.",
   del: "Deletes a file.",

--- a/components/apps/Terminal/useCommandInterpreter.ts
+++ b/components/apps/Terminal/useCommandInterpreter.ts
@@ -1,3 +1,4 @@
+import * as colors from "components/apps/Terminal/colorArgs.json";
 import {
   aliases,
   autoComplete,
@@ -77,11 +78,11 @@ const useCommandInterpreter = (
     },
     [localEcho, readdir, updateFolder]
   );
+  let colorOutput: string;
   const commandInterpreter = useCallback(
     async (command: string = ""): Promise<string> => {
       const [baseCommand = "", ...commandArgs] = parseCommand(command);
       const lcBaseCommand = baseCommand.toLowerCase();
-
       switch (lcBaseCommand) {
         case "cat":
         case "type": {
@@ -129,6 +130,15 @@ const useCommandInterpreter = (
           }
           break;
         }
+        case "color": {
+          const colorArgument = commandArgs[0].toUpperCase();
+          if (colors[colorArgument as keyof typeof colors]) {
+            colorOutput =
+              colors[colorArgument as keyof typeof colors]["color_code"];
+            localEcho?.println(colorOutput);
+          }
+          break;
+        }
         case "copy":
         case "cp": {
           const [source, destination] = commandArgs;
@@ -156,7 +166,7 @@ const useCommandInterpreter = (
         case "clear":
         case "cls":
           terminal?.reset();
-          terminal?.write("\u001Bc");
+          terminal?.write(`\u001Bc${colorOutput}`);
           break;
         case "date": {
           localEcho?.println(


### PR DESCRIPTION
because colors are nice
works the exact same way `color ` command does in windows cmd:

    ` color [attr]`
    0 = Black       8 = Gray
    1 = Blue        9 = Light Blue
    2 = Green       A = Light Green
    3 = Aqua        B = Light Aqua
    4 = Red         C = Light Red
    5 = Purple      D = Light Purple
    6 = Yellow      E = Light Yellow
    7 = White       F = Bright White


i have no idea what I'm doing, this is my first pull request.


