### PR TITLE
Some improvements to the Browser app

### DIFF
--- a/components/apps/Browser/WebViewer.ts
+++ b/components/apps/Browser/WebViewer.ts
@@ -1,0 +1,11 @@
+import styled from "styled-components";
+
+const WebViewer = styled.div`
+  iframe {
+    border: 0;
+    height: calc(100%);
+    width: 100%;
+  }
+`;
+
+export default WebViewer;

--- a/components/system/Files/FileEntry/extensions.ts
+++ b/components/system/Files/FileEntry/extensions.ts
@@ -8,6 +8,10 @@ type Extension = {
 export const TEXT_EDITORS = ["MonacoEditor", "Vim"];
 
 const types = {
+  AppHtmlDocument: {
+    process: ["Browser"],
+    type: "HTML App",
+  },
   Application: {
     icon: "executable",
     process: ["BoxedWine", "JSDOS"],
@@ -106,6 +110,7 @@ const types = {
 };
 
 const extensions = {
+  ".ahtml": types.AppHtmlDocument,
   ".asx": types.AudioPlaylist,
   ".exe": types.Application,
   ".gen": types.SegaGenesisRom,


### PR DESCRIPTION
Hi again!

I decided to try and improve the Browser app a bit, with the very limited TypeScript skills I have, and the following is what I did

- Fixed an oversight in the Browser code that previously made it impossible to open .HTM files
  - The .HTM extension was already correctly registered in `components/system/Files/FileEntry/extensions.ts` to open in the Browser. The problem was that, when opened, the Browser only checked for the .HTML extension to decide if the URL was a webpage or not, so it just treated the URL as a search query

- Registered a new file extension: .AHTML
  - It stands for "App HTML", and is meant for HTML files, ideally self-contained web apps, that open in a minimal browser Window (see below)

- Made the Browser load as a minimal webview-like window if it has to open an AHTML file
  - For HTML files with this extension, the Browser loads as a window without any UI elements (navigation buttons, omnibox, or bookmarks bar). As I said, it's ideal for apps. Demo video here: <https://user-images.githubusercontent.com/37557992/179304737-448994e4-c780-44af-8a96-0a07f688c6ab.mp4>

I also have some other ideas for the Browser, which I should likely propose in a ticket (for example, making the UI similar to the File Explorer one, instead of using the Chromium style, for consistency reasons), but for now, this is it!