### PR TITLE
Removed outdated GUI docs

### DIFF
--- a/public/System/Hexells/ca.js
+++ b/public/System/Hexells/ca.js
@@ -14,8 +14,7 @@ limitations under the License.
 
 /*
 Usage:
-  const gui = new dat.GUI();
-  const ca = new CA(gl, models_json, [W, H], gui); // gui is optional
+  const ca = new CA(gl, models_json, [W, H]);
   ca.step();
 
   ca.paint(x, y, radius, modelIndex);


### PR DESCRIPTION
Since you stripped the GUI component out of the `CA` class for the Hexell wallpaper, the commented documentation needed to be updated to reflect the change.