### PR TITLE
add AppInstaller program

### DIFF
--- a/components/apps/AppInstaller/StyledWindow.ts
+++ b/components/apps/AppInstaller/StyledWindow.ts
@@ -1,0 +1,29 @@
+import styled from "styled-components";
+
+const StyledWindow = styled.div`
+  .loading {
+    &::before {
+      color: #fff;
+      font-weight: 500;
+      mix-blend-mode: normal;
+      text-shadow: 1px 2px 3px rgba(0, 0, 0, 0.5);
+    }
+  }
+
+  .app-installer-window {
+    background: white;
+  }
+
+  button {
+    width: 80px;
+    height: 30px;
+  }
+
+  pre {
+    background: lightgray;
+    padding: 20px;
+    margin: 20px;
+  }
+`;
+
+export default StyledWindow;

--- a/components/apps/AppInstaller/index.tsx
+++ b/components/apps/AppInstaller/index.tsx
@@ -1,0 +1,88 @@
+import StyledWindow from "components/apps/AppInstaller/StyledWindow";
+import type { ComponentProcessProps } from "components/system/Apps/RenderComponent";
+import type { Extension } from "components/system/Files/FileEntry/extensions";
+import extensions from "components/system/Files/FileEntry/extensions";
+import StyledLoading from "components/system/Files/FileManager/StyledLoading";
+import { useFileSystem } from "contexts/fileSystem";
+import { useProcesses } from "contexts/process";
+import directory from "contexts/process/directory";
+import { useEffect, useState } from "react";
+
+const AppInstaller: FC<ComponentProcessProps> = ({ id }) => {
+  const { closeWithTransition, processes: { [id]: { url = "" } = {} } = {} } =
+    useProcesses();
+  const { createPath, exists, readFile, updateFolder, writeFile } =
+    useFileSystem();
+  const [loaded, setLoaded] = useState(false);
+  const [appDescriptor, setAppDescriptor] = useState(null);
+  const [approved, setApproved] = useState(false);
+
+  useEffect(() => {
+    if (url) {
+      readFile(url).then((buffer) => {
+        setLoaded(true);
+        const appDescriptor = JSON.parse(buffer.toString());
+        setAppDescriptor(appDescriptor);
+      });
+    }
+  }, [readFile, setLoaded, setAppDescriptor, url]);
+
+  useEffect(() => {
+    if (!appDescriptor) return;
+    if (!approved) return;
+    installApplication(appDescriptor);
+    // install complete
+    setAppDescriptor(null);
+    closeWithTransition(id);
+  }, [approved, appDescriptor, closeWithTransition, id]);
+
+  if (!loaded || !appDescriptor) {
+    return (
+      <StyledWindow>
+        <StyledLoading className="loading" />;
+      </StyledWindow>
+    );
+  }
+
+  return (
+    <StyledWindow className="app-installer-window">
+      Do you want to install "{appDescriptor.directoryEntry.title}"...
+      <pre>{appDescriptor.source}</pre>
+      <button onClick={() => setApproved(true)}>Install</button>
+    </StyledWindow>
+  );
+};
+
+export default AppInstaller;
+
+function installApplication(appDescriptor: Record<string, any>) {
+  const {
+    directoryEntry,
+    extensions: supportedExtensions,
+    source,
+  } = appDescriptor;
+
+  const { title: appTitle } = directoryEntry;
+  if (appTitle in directory) {
+    throw new Error(`Application "${appTitle}" already installed`);
+  }
+  const component = eval(source);
+  directory[appTitle] = {
+    ...directoryEntry,
+    Component: component,
+  };
+  supportedExtensions.forEach((ext: string) => {
+    // add to existing extension
+    if (ext in extensions) {
+      extensions[ext].process.push(appTitle);
+      return;
+    }
+    // add new extension
+    const newExtension: Extension = {
+      icon: "executable",
+      process: [appTitle],
+      type: "unknown",
+    };
+    extensions[ext] = newExtension;
+  });
+}

--- a/components/apps/AppInstaller/index.tsx
+++ b/components/apps/AppInstaller/index.tsx
@@ -55,7 +55,11 @@ const AppInstaller: FC<ComponentProcessProps> = ({ id }) => {
 
 export default AppInstaller;
 
-function installApplication(appDescriptor: Record<string, any>) {
+// consider creating a fsImport that imports from local fs
+//   const code = 'export const foo = 123'
+//   const imported = await import(`data:text/javascript;charset=utf-8,${encodeURIComponent(code)}`)
+//   console.log(imported.foo) // Should print 123
+export function installApplication(appDescriptor: Record<string, any>) {
   const {
     directoryEntry,
     extensions: supportedExtensions,

--- a/components/system/Apps/AppsLoader.tsx
+++ b/components/system/Apps/AppsLoader.tsx
@@ -1,31 +1,82 @@
+import { installApplication } from "components/apps/AppInstaller";
+import { useFileSystem } from "contexts/fileSystem";
 import { ProcessConsumer } from "contexts/process";
 import { AnimatePresence } from "framer-motion";
 import dynamic from "next/dynamic";
+import { useEffect, useRef } from "react";
 
 const RenderComponent = dynamic(
   () => import("components/system/Apps/RenderComponent")
 );
 
-const AppsLoader: FC = () => (
-  <ProcessConsumer>
-    {({ processes = {} }) => (
-      <AnimatePresence initial={false} presenceAffectsLayout={false}>
-        {Object.entries(processes).map(
-          ([id, { closing, Component, hasWindow }]) =>
-            id &&
-            Component &&
-            !closing && (
-              <RenderComponent
-                key={id}
-                Component={Component}
-                hasWindow={hasWindow}
-                id={id}
-              />
-            )
-        )}
-      </AnimatePresence>
-    )}
-  </ProcessConsumer>
-);
+const AppsLoader: FC = () => {
+  const appsInitialized = useRef(false);
+  const {
+    fs,
+    readdir,
+    readFile,
+    stat,
+  } = useFileSystem();
+
+  useEffect(() => {
+    if (!fs) return;
+    console.log(fs);
+    // run once
+    if (appsInitialized.current) return;
+    appsInitialized.current = true;
+    // initialize apps
+    console.log("files");
+    (async function () {
+      // find application directories
+      const files = await readdir("/Applications");
+      const applicationDirs = [];
+      await Promise.all(
+        files.map(async (file) => {
+          const path = `/Applications/${file}`;
+          const details = await stat(path);
+          if (details.isDirectory()) {
+            applicationDirs.push(path);
+          }
+          console.log(details);
+        })
+      );
+      // install each application
+      await Promise.all(
+        applicationDirs.map(async (dir) => {
+          const appManifestBuffer = await readFile(`${dir}/manifest.json`);
+          const appManifest = JSON.parse(appManifestBuffer.toString());
+          // TODO: installing here, the "open with" context menu doesn't populate
+          try {
+            installApplication(appManifest);
+          } catch (e) {
+            console.error(e);
+          }
+        })
+      );
+    })();
+  }, [fs, readdir, readFile, stat]);
+
+  return (
+    <ProcessConsumer>
+      {({ processes = {} }) => (
+        <AnimatePresence initial={false} presenceAffectsLayout={false}>
+          {Object.entries(processes).map(
+            ([id, { closing, Component, hasWindow }]) =>
+              id &&
+              Component &&
+              !closing && (
+                <RenderComponent
+                  key={id}
+                  Component={Component}
+                  hasWindow={hasWindow}
+                  id={id}
+                />
+              )
+          )}
+        </AnimatePresence>
+      )}
+    </ProcessConsumer>
+  );
+};
 
 export default AppsLoader;

--- a/components/system/Files/FileEntry/extensions.ts
+++ b/components/system/Files/FileEntry/extensions.ts
@@ -11,6 +11,11 @@ export type Extension = {
 export const TEXT_EDITORS = ["MonacoEditor", "Vim"];
 
 const types = {
+  AppInstaller: {
+    icon: "executable",
+    process: ["AppInstaller"],
+    type: "App Installer",
+  },
   Application: {
     icon: "executable",
     process: ["BoxedWine", "JSDOS"],
@@ -52,11 +57,6 @@ const types = {
     icon: "marked",
     process: ["Marked", ...TEXT_EDITORS],
     type: "Markdown File",
-  },
-  AppInstaller: {
-    icon: "executable",
-    process: ["AppInstaller"],
-    type: "App Installer",
   },
   MediaPlaylist: {
     process: ["VideoPlayer"],
@@ -114,12 +114,12 @@ const extensions: Record<string, Extension> = {
   ".htm": types.HtmlDocument,
   ".html": types.HtmlDocument,
   ".img": types.DiscImage,
+  ".install": types.AppInstaller,
   ".iso": types.MountableDiscImage,
   ".jsdos": types.JsdosBundle,
   ".m3u": types.AudioPlaylist,
   ".m3u8": types.MediaPlaylist,
   ".md": types.Markdown,
-  ".install": types.AppInstaller,
   ".mp3": types.Music,
   ".pdf": types.PdfDocument,
   ".pls": types.AudioPlaylist,

--- a/components/system/Files/FileEntry/extensions.ts
+++ b/components/system/Files/FileEntry/extensions.ts
@@ -1,7 +1,7 @@
 import { emulatorCores } from "components/apps/Emulator/config";
 import { EDITABLE_IMAGE_FILE_EXTENSIONS } from "utils/constants";
 
-type Extension = {
+export type Extension = {
   command?: string;
   icon?: string;
   process: string[];
@@ -52,6 +52,11 @@ const types = {
     icon: "marked",
     process: ["Marked", ...TEXT_EDITORS],
     type: "Markdown File",
+  },
+  AppInstaller: {
+    icon: "executable",
+    process: ["AppInstaller"],
+    type: "App Installer",
   },
   MediaPlaylist: {
     process: ["VideoPlayer"],
@@ -114,6 +119,7 @@ const extensions: Record<string, Extension> = {
   ".m3u": types.AudioPlaylist,
   ".m3u8": types.MediaPlaylist,
   ".md": types.Markdown,
+  ".install": types.AppInstaller,
   ".mp3": types.Music,
   ".pdf": types.PdfDocument,
   ".pls": types.AudioPlaylist,

--- a/contexts/process/directory.ts
+++ b/contexts/process/directory.ts
@@ -62,6 +62,12 @@ const directory: Processes = {
     lockAspectRatio: true,
     title: "DX-Ball",
   },
+  AppInstaller: {
+    Component: dynamic(() => import("components/apps/AppInstaller")),
+    allowResizing: false,
+    icon: "/System/Icons/exterm.webp",
+    title: "AppInstaller",
+  },
   DevTools: {
     Component: dynamic(() => import("components/apps/DevTools")),
     background: "rgb(36, 36, 36)",
@@ -178,12 +184,6 @@ const directory: Processes = {
     hideTitlebarIcon: true,
     icon: "/System/Icons/photos.webp",
     title: "Photos",
-  },
-  AppInstaller: {
-    Component: dynamic(() => import("components/apps/AppInstaller")),
-    allowResizing: false,
-    icon: "/System/Icons/exterm.webp",
-    title: "AppInstaller",
   },
   Ruffle: {
     Component: dynamic(() => import("components/apps/Ruffle")),

--- a/contexts/process/directory.ts
+++ b/contexts/process/directory.ts
@@ -179,6 +179,12 @@ const directory: Processes = {
     icon: "/System/Icons/photos.webp",
     title: "Photos",
   },
+  AppInstaller: {
+    Component: dynamic(() => import("components/apps/AppInstaller")),
+    allowResizing: false,
+    icon: "/System/Icons/exterm.webp",
+    title: "AppInstaller",
+  },
   Ruffle: {
     Component: dynamic(() => import("components/apps/Ruffle")),
     background: "#000",

--- a/public/Applications/HelloWorld/manifest.json
+++ b/public/Applications/HelloWorld/manifest.json
@@ -1,0 +1,8 @@
+{
+    "directoryEntry": {
+        "title": "HellowWorld",
+        "icon": "/System/Icons/emulator.webp"
+    },
+    "source": "() => { return 'hello world' }",
+    "extensions": [".xyz"]
+}


### PR DESCRIPTION
Updates #211 

ok i took a swing at it
didnt actually do persistence

create a file `test.install`
```json
{
    "directoryEntry": {
        "title": "testApp",
        "icon": "/System/Icons/emulator.webp"
    },
    "source": "() => { return 'hello world' }",
    "extensions": [".xyz"]
}
```

and an empty file `test.xyz`
```
(empty)
```

1. run `test.install`
2. review the details and click "install"
3. refresh desktop and notice `test.xyz` icon change
4. run `test.xyz` and see the installed app open