### PR TITLE
Adding a few more commands for the github client

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '2'
+services:
+  daedalos:
+    image: daedalos
+    ports:
+      - '3045:3000'


### PR DESCRIPTION
This adds the ability to git add files, create commits, and push commits to the remote repo. `git status` also works.

I was very interested in making git as close as possible to an actual git client but now I'm exploring the linux route to be able to have a fully functional git terminal in dadedalOS, so I paused this work. Since I did get some features working I figured I would share this PR as a starting point.

Notes:
* The git user is John Doe since I don't have any reference to the user and git cofig is not implemented.
* There is no auth. Only works on public repos.
* Ignore the docker compose.

