### PR TITLE
bugfix: context menu actions fire twice on click

### DIFF
--- a/components/system/Menu/MenuItemEntry.tsx
+++ b/components/system/Menu/MenuItemEntry.tsx
@@ -120,7 +120,6 @@ const MenuItemEntry: FC<MenuItemEntryProps> = ({
         <Button
           as="figure"
           className={showSubMenu ? "active" : undefined}
-          onClick={triggerAction}
           onMouseUp={triggerAction}
         >
           {icon && <Icon alt={label} imgSize={16} src={icon} />}


### PR DESCRIPTION
menu selection works as expected after this change.

edit: i originally thought this was only happening on firefox but I'm seeing it on chrome as well

Fixes: https://github.com/DustinBrett/daedalOS/issues/298