### PR TITLE
Fix to avoid crashes on macOS

### DIFF
--- a/components/system/Files/FileEntry/index.tsx
+++ b/components/system/Files/FileEntry/index.tsx
@@ -222,6 +222,11 @@ const FileEntry: FC<FileEntryProps> = ({
       return "";
     }
 
+    // Important check to avoid crashes on macOS
+    if (path.includes("__MACOSX") || path.includes(".DS_Store")) {
+      return `Type: Mac hidden file`;
+    }
+
     const type =
       extensions[extension]?.type ||
       `${extension.toUpperCase().replace(".", "")} File`;


### PR DESCRIPTION
I experienced frequent crashes on macOS due to browserfs attempting to access hidden or non-existing .DS_Store files. This code resolves the issue.