### PR TITLE
Changed yarn start from 'next start' to 'npx serve@latest out'

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "export": "next export",
     "prepare": "husky install",
     "prettier": "prettier --write .",
-    "start": "next start",
+    "start": "npx serve@latest out",
     "stylelint": "stylelint --formatter=verbose **/*.ts*",
     "test": "jest",
     "unused-exports": "ts-prune --project tsconfig.json --ignore \"\\pages|\\e2e\" --error"


### PR DESCRIPTION
Hi, after the change of creating the .index, the build went great but it didn't start. I managed to solve this changing the command of yarn start. Here is the error message:

```yarn start
yarn run v1.22.19
$ next start
   ▲ Next.js 14.0.3
   - Local:        http://localhost:3000

Error: "next start" does not work with "output: export" configuration. Use "npx serve@latest out" instead.
    at /root/daedalOS/node_modules/next/dist/server/next.js:208:31
    at async NextServer.prepare (/root/daedalOS/node_modules/next/dist/server/next.js:152:24)
    at async initializeImpl (/root/daedalOS/node_modules/next/dist/server/lib/render-server.js:91:5)
    at async initialize (/root/daedalOS/node_modules/next/dist/server/lib/router-server.js:103:22)
    at async Server.<anonymous> (/root/daedalOS/node_modules/next/dist/server/lib/start-server.js:236:36)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.```