### PR TITLE
Fix: Add missing "date" variable declaration in robots.js

### DIFF
--- a/scripts/robots.js
+++ b/scripts/robots.js
@@ -21,6 +21,7 @@ const buildFileSitemap = (path, excludePaths, callback) => {
     const entryPath = join(path, entry);
     const urlEntryPath = entryPath.replace(/\\/g, "/");
     const stats = statSync(join(publicPath, entry));
+    const date = new Date();
 
     if (stats.isDirectory()) {
       if (!excludePaths.includes(urlEntryPath)) {


### PR DESCRIPTION
The date variable was missing, leading to a reference error when calling `date.getTimezoneOffset()`.
I added `const date = new Date();`