### PR TITLE
feat(PDF): update window title logic to match Chrome behavior

### DIFF
--- a/components/apps/PDF/usePDF.ts
+++ b/components/apps/PDF/usePDF.ts
@@ -112,9 +112,15 @@ const usePDF = (
 
           pdfWorker.current = loader._worker as PDFWorker;
 
-          argument(id, "subTitle", (info as MetadataInfo).Title);
-          argument(id, "count", doc.numPages);
-          prependFileToTitle(basename(url));
+          const metadataTitle = (info as MetadataInfo).Title;
+          argument(id, "subTitle", metadataTitle);
+          argument(id, "count", doc?.numPages ?? 0);
+
+          if (metadataTitle !== undefined && metadataTitle !== null) {
+            prependFileToTitle(metadataTitle);
+          } else {
+            prependFileToTitle(basename(url));
+          }
 
           abortControllerRef.current = new AbortController();
 


### PR DESCRIPTION
## Changes
- Modified the title logic in `usePDF.ts` to:
  - Use the PDF's metadata title as the window title if it exists
  - Fallback to the filename if no metadata title is present

## Testing
1. Open a PDF with metadata title
   - Window title should show the metadata title
2. Open a PDF without metadata title
   - Window title should show the filename
3. Open multiple PDFs
   - Each window should show the correct title based on the above rules

![Screenshot 2025-04-03 at 10 57 16 PM](https://github.com/user-attachments/assets/7c4a7e80-ea88-41fa-8236-95def068f13e)

## Related Issues
Closes #569