### PR TITLE
feat: add draggable desktop widgets (clock, calendar, weather, youtube)

### DIFF
--- a/components/system/Desktop/Widgets/CalendarWidget/StyledCalendarWidget.ts
+++ b/components/system/Desktop/Widgets/CalendarWidget/StyledCalendarWidget.ts
@@ -1,0 +1,85 @@
+import styled from "styled-components";
+import StyledWidget from "components/system/Desktop/Widgets/StyledWidget";
+
+const StyledCalendarWidget = styled(StyledWidget)`
+  min-width: 280px;
+
+  .calendar-nav {
+    align-items: center;
+    display: flex;
+    gap: 8px;
+    justify-content: space-between;
+    padding: 4px 14px 8px;
+  }
+
+  .calendar-month {
+    font-size: 14px;
+    font-weight: 500;
+  }
+
+  .calendar-nav-buttons {
+    display: flex;
+    gap: 4px;
+  }
+
+  .calendar-nav-buttons button {
+    background: none;
+    border: 0;
+    border-radius: 4px;
+    color: ${({ theme }) => theme.colors.text};
+    cursor: pointer;
+    font-size: 14px;
+    height: 28px;
+    line-height: 28px;
+    padding: 0;
+    width: 28px;
+
+    &:hover {
+      background-color: ${({ theme }) => theme.colors.taskbar.hover};
+    }
+
+    &:active {
+      background-color: ${({ theme }) => theme.colors.taskbar.foreground};
+    }
+  }
+
+  table {
+    border-collapse: collapse;
+    padding: 0 8px 10px;
+    width: 100%;
+  }
+
+  th {
+    color: ${({ theme }) => theme.colors.text};
+    font-size: 11px;
+    font-weight: 400;
+    opacity: 50%;
+    padding: 4px 0;
+    text-align: center;
+    width: 40px;
+  }
+
+  td {
+    border-radius: 50%;
+    font-size: 12px;
+    height: 32px;
+    text-align: center;
+    width: 40px;
+
+    &.prev,
+    &.next {
+      opacity: 30%;
+    }
+
+    &.today {
+      background-color: rgb(0 120 215);
+      font-weight: 600;
+    }
+
+    &:not(.today, .prev, .next):hover {
+      background-color: ${({ theme }) => theme.colors.taskbar.hover};
+    }
+  }
+`;
+
+export default StyledCalendarWidget;

--- a/components/system/Desktop/Widgets/CalendarWidget/index.tsx
+++ b/components/system/Desktop/Widgets/CalendarWidget/index.tsx
@@ -1,0 +1,94 @@
+import { memo, useCallback, useMemo, useState } from "react";
+import StyledCalendarWidget from "components/system/Desktop/Widgets/CalendarWidget/StyledCalendarWidget";
+import {
+  type Calendar,
+  createCalendar,
+} from "components/system/Taskbar/Calendar/functions";
+import useDraggableWidget, {
+  type Position,
+} from "components/system/Desktop/Widgets/useDraggableWidget";
+
+const DAY_NAMES = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"];
+
+type CalendarWidgetProps = {
+  defaultPosition: Position;
+};
+
+const CalendarWidget: FC<CalendarWidgetProps> = ({ defaultPosition }) => {
+  const [date, setDate] = useState(() => new Date());
+  const [calendar, setCalendar] = useState<Calendar>(() =>
+    createCalendar(date)
+  );
+  const { dragHandleProps, style } = useDraggableWidget(defaultPosition);
+  const today = useMemo(() => new Date(), []);
+
+  const isCurrentDate = useMemo(
+    () =>
+      date.getMonth() === today.getMonth() &&
+      date.getFullYear() === today.getFullYear(),
+    [date, today]
+  );
+
+  const changeMonth = useCallback(
+    (direction: number): void => {
+      const newDate = new Date(date);
+      const newMonth = newDate.getMonth() + direction;
+
+      newDate.setDate(1);
+      newDate.setMonth(newMonth);
+
+      const resolvedMonth =
+        newMonth === 12 ? 0 : newMonth === -1 ? 11 : newMonth;
+      const isCurrentMonth = resolvedMonth === today.getMonth();
+
+      if (isCurrentMonth) newDate.setDate(today.getDate());
+
+      setDate(newDate);
+      setCalendar(createCalendar(newDate));
+    },
+    [date, today]
+  );
+
+  const monthLabel = `${date.toLocaleString("en-US", { month: "long" })}, ${date.getFullYear()}`;
+
+  return (
+    <StyledCalendarWidget data-widget="calendar" style={style}>
+      <div className="widget-header" {...dragHandleProps}>
+        <span style={{ fontSize: "11px", opacity: 0.6 }}>Calendar</span>
+      </div>
+      <div className="calendar-nav">
+        <span className="calendar-month">{monthLabel}</span>
+        <div className="calendar-nav-buttons">
+          <button onClick={() => changeMonth(-1)} type="button">
+            &#9650;
+          </button>
+          <button onClick={() => changeMonth(1)} type="button">
+            &#9660;
+          </button>
+        </div>
+      </div>
+      <table>
+        <thead>
+          <tr>
+            {DAY_NAMES.map((dayName) => (
+              <th key={dayName}>{dayName}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className={isCurrentDate ? "curr" : undefined}>
+          {calendar.map((week) => (
+            <tr key={week.toString()}>
+              {week.map(([day, type]) => (
+                <td key={`${day}${type}`} className={type}>
+                  {day}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </StyledCalendarWidget>
+  );
+};
+
+export default memo(CalendarWidget);

--- a/components/system/Desktop/Widgets/ClockWidget/StyledClockWidget.ts
+++ b/components/system/Desktop/Widgets/ClockWidget/StyledClockWidget.ts
@@ -1,0 +1,22 @@
+import styled from "styled-components";
+import StyledWidget from "components/system/Desktop/Widgets/StyledWidget";
+
+const StyledClockWidget = styled(StyledWidget)`
+  min-width: 220px;
+
+  .clock-time {
+    font-size: 48px;
+    font-weight: 200;
+    letter-spacing: -1px;
+    line-height: 1;
+    padding: 6px 14px 0;
+  }
+
+  .clock-date {
+    font-size: 13px;
+    opacity: 80%;
+    padding: 6px 14px 14px;
+  }
+`;
+
+export default StyledClockWidget;

--- a/components/system/Desktop/Widgets/ClockWidget/index.tsx
+++ b/components/system/Desktop/Widgets/ClockWidget/index.tsx
@@ -1,0 +1,61 @@
+import { memo, useCallback, useEffect, useState } from "react";
+import StyledClockWidget from "components/system/Desktop/Widgets/ClockWidget/StyledClockWidget";
+import useDraggableWidget, {
+  type Position,
+} from "components/system/Desktop/Widgets/useDraggableWidget";
+import { MILLISECONDS_IN_SECOND } from "utils/constants";
+
+const DEFAULT_LOCALE = "en";
+
+const timeFormatter = new Intl.DateTimeFormat(DEFAULT_LOCALE, {
+  hour: "numeric",
+  hour12: true,
+  minute: "2-digit",
+});
+
+const dateFormatter = new Intl.DateTimeFormat(DEFAULT_LOCALE, {
+  day: "numeric",
+  month: "long",
+  weekday: "long",
+  year: "numeric",
+});
+
+type ClockWidgetProps = {
+  defaultPosition: Position;
+};
+
+const formatTime = (now: Date): string => timeFormatter.format(now);
+const formatDate = (now: Date): string => dateFormatter.format(now);
+
+const ClockWidget: FC<ClockWidgetProps> = ({ defaultPosition }) => {
+  const [now, setNow] = useState(() => new Date());
+  const { dragHandleProps, style } = useDraggableWidget(defaultPosition);
+
+  const tick = useCallback((): void => {
+    setNow(new Date());
+  }, []);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      tick();
+      const interval = setInterval(tick, MILLISECONDS_IN_SECOND);
+
+      return (): void => clearInterval(interval);
+    }, MILLISECONDS_IN_SECOND - now.getMilliseconds());
+
+    return (): void => clearTimeout(timeout);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tick]);
+
+  return (
+    <StyledClockWidget data-widget="clock" style={style}>
+      <div className="widget-header" {...dragHandleProps}>
+        <span style={{ fontSize: "11px", opacity: 0.6 }}>Clock</span>
+      </div>
+      <div className="clock-time">{formatTime(now)}</div>
+      <div className="clock-date">{formatDate(now)}</div>
+    </StyledClockWidget>
+  );
+};
+
+export default memo(ClockWidget);

--- a/components/system/Desktop/Widgets/StyledWidget.ts
+++ b/components/system/Desktop/Widgets/StyledWidget.ts
@@ -1,0 +1,23 @@
+import styled from "styled-components";
+
+const StyledWidget = styled.div`
+  backdrop-filter: ${({ theme }) => `blur(${theme.sizes.taskbar.panelBlur})`};
+  background-color: ${({ theme }) => theme.colors.taskbar.background};
+  border: ${({ theme }) => `1px solid ${theme.colors.taskbar.peekBorder}`};
+  border-radius: 8px;
+  box-shadow: ${({ theme }) => theme.colors.window.shadow};
+  color: ${({ theme }) => theme.colors.text};
+  font-family: ${({ theme }) => theme.formats.systemFont};
+  overflow: hidden;
+  user-select: none;
+  z-index: 1;
+
+  .widget-header {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+    padding: 10px 14px 6px;
+  }
+`;
+
+export default StyledWidget;

--- a/components/system/Desktop/Widgets/WeatherWidget/StyledWeatherWidget.ts
+++ b/components/system/Desktop/Widgets/WeatherWidget/StyledWeatherWidget.ts
@@ -1,0 +1,48 @@
+import styled from "styled-components";
+import StyledWidget from "components/system/Desktop/Widgets/StyledWidget";
+
+const StyledWeatherWidget = styled(StyledWidget)`
+  min-width: 220px;
+
+  .weather-body {
+    display: flex;
+    gap: 12px;
+    padding: 2px 14px 14px;
+  }
+
+  .weather-emoji {
+    font-size: 40px;
+    line-height: 1;
+  }
+
+  .weather-info {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+  }
+
+  .weather-temp {
+    font-size: 28px;
+    font-weight: 300;
+    line-height: 1;
+  }
+
+  .weather-desc {
+    font-size: 12px;
+    opacity: 80%;
+  }
+
+  .weather-location {
+    font-size: 11px;
+    opacity: 60%;
+  }
+
+  .weather-loading,
+  .weather-error {
+    font-size: 12px;
+    opacity: 60%;
+    padding: 8px 14px 14px;
+  }
+`;
+
+export default StyledWeatherWidget;

--- a/components/system/Desktop/Widgets/WeatherWidget/index.tsx
+++ b/components/system/Desktop/Widgets/WeatherWidget/index.tsx
@@ -1,0 +1,48 @@
+import { memo } from "react";
+import StyledWeatherWidget from "components/system/Desktop/Widgets/WeatherWidget/StyledWeatherWidget";
+import useWeather, {
+  getWeatherEmoji,
+} from "components/system/Desktop/Widgets/WeatherWidget/useWeather";
+import useDraggableWidget, {
+  type Position,
+} from "components/system/Desktop/Widgets/useDraggableWidget";
+
+type WeatherWidgetProps = {
+  defaultPosition: Position;
+};
+
+const WeatherWidget: FC<WeatherWidgetProps> = ({ defaultPosition }) => {
+  const { data, error, loading } = useWeather();
+  const { dragHandleProps, style } = useDraggableWidget(defaultPosition);
+
+  return (
+    <StyledWeatherWidget data-widget="weather" style={style}>
+      <div className="widget-header" {...dragHandleProps}>
+        <span style={{ fontSize: "11px", opacity: 0.6 }}>Weather</span>
+      </div>
+      {loading && !data && (
+        <div className="weather-loading">Loading weather...</div>
+      )}
+      {error && !data && (
+        <div className="weather-error">Unable to load weather data</div>
+      )}
+      {data && (
+        <div className="weather-body">
+          <span className="weather-emoji">
+            {getWeatherEmoji(data.description)}
+          </span>
+          <div className="weather-info">
+            <span className="weather-temp">{data.tempC}&deg;C</span>
+            <span className="weather-desc">{data.description}</span>
+            <span className="weather-location">
+              {data.city}
+              {data.country ? `, ${data.country}` : ""}
+            </span>
+          </div>
+        </div>
+      )}
+    </StyledWeatherWidget>
+  );
+};
+
+export default memo(WeatherWidget);

--- a/components/system/Desktop/Widgets/WeatherWidget/useWeather.ts
+++ b/components/system/Desktop/Widgets/WeatherWidget/useWeather.ts
@@ -1,0 +1,112 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+type WeatherCondition = {
+  temp_C: string;
+  temp_F: string;
+  weatherDesc: { value: string }[];
+  weatherIconUrl: { value: string }[];
+};
+
+type WttrResponse = {
+  current_condition: WeatherCondition[];
+  nearest_area: {
+    areaName: { value: string }[];
+    country: { value: string }[];
+  }[];
+};
+
+type WeatherData = {
+  city: string;
+  country: string;
+  description: string;
+  tempC: string;
+  tempF: string;
+};
+
+type UseWeatherReturn = {
+  data: WeatherData | undefined;
+  error: boolean;
+  loading: boolean;
+};
+
+const WTTR_API = "https://wttr.in/?format=j1";
+const REFRESH_INTERVAL_MS = 1_800_000; // 30 minutes
+
+const WEATHER_EMOJI_MAP: Record<string, string> = {
+  Clear: "\u2600\uFE0F",
+  Cloudy: "\u2601\uFE0F",
+  Fog: "\uD83C\uDF2B\uFE0F",
+  "Heavy rain": "\uD83C\uDF27\uFE0F",
+  "Heavy snow": "\u2744\uFE0F",
+  "Light drizzle": "\uD83C\uDF26\uFE0F",
+  "Light rain": "\uD83C\uDF26\uFE0F",
+  "Light rain shower": "\uD83C\uDF26\uFE0F",
+  "Light snow": "\uD83C\uDF28\uFE0F",
+  "Moderate rain": "\uD83C\uDF27\uFE0F",
+  "Moderate snow": "\uD83C\uDF28\uFE0F",
+  Overcast: "\u2601\uFE0F",
+  "Partly Cloudy": "\u26C5",
+  "Partly cloudy": "\u26C5",
+  "Patchy rain nearby": "\uD83C\uDF26\uFE0F",
+  "Patchy rain possible": "\uD83C\uDF26\uFE0F",
+  Sunny: "\u2600\uFE0F",
+  Thunderstorm: "\u26C8\uFE0F",
+};
+
+export const getWeatherEmoji = (description: string): string =>
+  WEATHER_EMOJI_MAP[description] ?? "\uD83C\uDF24\uFE0F";
+
+const useWeather = (): UseWeatherReturn => {
+  const [data, setData] = useState<WeatherData>();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval>>(undefined);
+
+  const fetchWeather = useCallback(async (): Promise<void> => {
+    try {
+      setLoading(true);
+      setError(false);
+
+      const response = await fetch(WTTR_API);
+
+      if (!response.ok) {
+        setError(true);
+        return;
+      }
+
+      const json = (await response.json()) as WttrResponse;
+      const condition = json.current_condition?.[0];
+      const area = json.nearest_area?.[0];
+
+      if (!condition || !area) {
+        setError(true);
+        return;
+      }
+
+      setData({
+        city: area.areaName[0]?.value ?? "Unknown",
+        country: area.country[0]?.value ?? "",
+        description: condition.weatherDesc[0]?.value ?? "Unknown",
+        tempC: condition.temp_C,
+        tempF: condition.temp_F,
+      });
+    } catch {
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchWeather();
+    intervalRef.current = setInterval(fetchWeather, REFRESH_INTERVAL_MS);
+
+    return (): void => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, [fetchWeather]);
+
+  return { data, error, loading };
+};
+
+export default useWeather;

--- a/components/system/Desktop/Widgets/YouTubeWidget/StyledYouTubeWidget.ts
+++ b/components/system/Desktop/Widgets/YouTubeWidget/StyledYouTubeWidget.ts
@@ -1,0 +1,19 @@
+import styled from "styled-components";
+import StyledWidget from "components/system/Desktop/Widgets/StyledWidget";
+
+const StyledYouTubeWidget = styled(StyledWidget)`
+  width: 360px;
+
+  .youtube-body {
+    padding: 0 0 4px;
+  }
+
+  iframe {
+    aspect-ratio: 16 / 9;
+    border: 0;
+    display: block;
+    width: 100%;
+  }
+`;
+
+export default StyledYouTubeWidget;

--- a/components/system/Desktop/Widgets/YouTubeWidget/index.tsx
+++ b/components/system/Desktop/Widgets/YouTubeWidget/index.tsx
@@ -1,0 +1,35 @@
+import { memo } from "react";
+import StyledYouTubeWidget from "components/system/Desktop/Widgets/YouTubeWidget/StyledYouTubeWidget";
+import useDraggableWidget, {
+  type Position,
+} from "components/system/Desktop/Widgets/useDraggableWidget";
+
+const YOUTUBE_VIDEO_ID = "dQw4w9WgXcQ";
+const EMBED_URL = `https://www.youtube.com/embed/${YOUTUBE_VIDEO_ID}`;
+
+type YouTubeWidgetProps = {
+  defaultPosition: Position;
+};
+
+const YouTubeWidget: FC<YouTubeWidgetProps> = ({ defaultPosition }) => {
+  const { dragHandleProps, style } = useDraggableWidget(defaultPosition);
+
+  return (
+    <StyledYouTubeWidget data-widget="youtube" style={style}>
+      <div className="widget-header" {...dragHandleProps}>
+        <span style={{ fontSize: "11px", opacity: 0.6 }}>YouTube</span>
+      </div>
+      <div className="youtube-body">
+        <iframe
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          credentialless=""
+          src={EMBED_URL}
+          title="YouTube video"
+          allowFullScreen
+        />
+      </div>
+    </StyledYouTubeWidget>
+  );
+};
+
+export default memo(YouTubeWidget);

--- a/components/system/Desktop/Widgets/index.tsx
+++ b/components/system/Desktop/Widgets/index.tsx
@@ -1,0 +1,21 @@
+import { memo } from "react";
+import ClockWidget from "components/system/Desktop/Widgets/ClockWidget";
+import WeatherWidget from "components/system/Desktop/Widgets/WeatherWidget";
+import CalendarWidget from "components/system/Desktop/Widgets/CalendarWidget";
+import YouTubeWidget from "components/system/Desktop/Widgets/YouTubeWidget";
+
+const CLOCK_POSITION = { x: -260, y: 40 };
+const WEATHER_POSITION = { x: -260, y: 200 };
+const CALENDAR_POSITION = { x: -320, y: 360 };
+const YOUTUBE_POSITION = { x: -400, y: 40 };
+
+const WidgetManager: FC = () => (
+  <>
+    <ClockWidget defaultPosition={CLOCK_POSITION} />
+    <WeatherWidget defaultPosition={WEATHER_POSITION} />
+    <CalendarWidget defaultPosition={CALENDAR_POSITION} />
+    <YouTubeWidget defaultPosition={YOUTUBE_POSITION} />
+  </>
+);
+
+export default memo(WidgetManager);

--- a/components/system/Desktop/Widgets/useDraggableWidget.ts
+++ b/components/system/Desktop/Widgets/useDraggableWidget.ts
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { TASKBAR_HEIGHT } from "utils/constants";
+
+type Position = {
+  x: number;
+  y: number;
+};
+
+type DragHandleProps = {
+  onMouseDown: (event: React.MouseEvent) => void;
+  style: { cursor: "grab" | "grabbing" };
+};
+
+type UseDraggableWidgetReturn = {
+  dragHandleProps: DragHandleProps;
+  position: Position;
+  style: React.CSSProperties;
+};
+
+const resolvePosition = (pos: Position): Position => ({
+  x: pos.x < 0 ? window.innerWidth + pos.x : pos.x,
+  y: pos.y < 0 ? window.innerHeight + pos.y : pos.y,
+});
+
+const useDraggableWidget = (
+  defaultPosition: Position
+): UseDraggableWidgetReturn => {
+  const [position, setPosition] = useState<Position>({ x: 0, y: 0 });
+  const initializedRef = useRef(false);
+  const draggingRef = useRef(false);
+  const offsetRef = useRef<Position>({ x: 0, y: 0 });
+  const widgetSizeRef = useRef<{ height: number; width: number }>({
+    height: 0,
+    width: 0,
+  });
+
+  useEffect(() => {
+    if (!initializedRef.current) {
+      initializedRef.current = true;
+      setPosition(resolvePosition(defaultPosition));
+    }
+  }, [defaultPosition]);
+
+  const onMouseMove = useCallback((event: MouseEvent): void => {
+    if (!draggingRef.current) return;
+
+    const maxX = window.innerWidth - widgetSizeRef.current.width;
+    const maxY =
+      window.innerHeight - TASKBAR_HEIGHT - widgetSizeRef.current.height;
+
+    const nextX = Math.max(
+      0,
+      Math.min(event.clientX - offsetRef.current.x, maxX)
+    );
+    const nextY = Math.max(
+      0,
+      Math.min(event.clientY - offsetRef.current.y, maxY)
+    );
+
+    setPosition({ x: nextX, y: nextY });
+  }, []);
+
+  const onMouseUp = useCallback((): void => {
+    draggingRef.current = false;
+    document.removeEventListener("mousemove", onMouseMove);
+    document.removeEventListener("mouseup", onMouseUp);
+  }, [onMouseMove]);
+
+  const onMouseDown = useCallback(
+    (event: React.MouseEvent): void => {
+      const target = event.currentTarget as HTMLElement;
+      const widget = target.closest("[data-widget]");
+
+      if (widget) {
+        const rect = widget.getBoundingClientRect();
+
+        widgetSizeRef.current = {
+          height: rect.height,
+          width: rect.width,
+        };
+        offsetRef.current = {
+          x: event.clientX - rect.left,
+          y: event.clientY - rect.top,
+        };
+      }
+
+      draggingRef.current = true;
+      document.addEventListener("mousemove", onMouseMove);
+      document.addEventListener("mouseup", onMouseUp);
+    },
+    [onMouseMove, onMouseUp]
+  );
+
+  useEffect(
+    () => (): void => {
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+    },
+    [onMouseMove, onMouseUp]
+  );
+
+  return {
+    dragHandleProps: {
+      onMouseDown,
+      style: { cursor: draggingRef.current ? "grabbing" : "grab" },
+    },
+    position,
+    style: {
+      left: position.x,
+      position: "absolute" as const,
+      top: position.y,
+    },
+  };
+};
+
+export default useDraggableWidget;
+export type { Position };

--- a/components/system/Desktop/index.tsx
+++ b/components/system/Desktop/index.tsx
@@ -1,6 +1,7 @@
 import { memo, useRef } from "react";
 import StyledDesktop from "components/system/Desktop/StyledDesktop";
 import useWallpaper from "components/system/Desktop/Wallpapers/useWallpaper";
+import WidgetManager from "components/system/Desktop/Widgets";
 import FileManager from "components/system/Files/FileManager";
 import { DESKTOP_PATH } from "utils/constants";
 
@@ -19,6 +20,7 @@ const Desktop: FC = ({ children }) => {
         isDesktop
         loadIconsImmediately
       />
+      <WidgetManager />
       {children}
     </StyledDesktop>
   );


### PR DESCRIPTION
Introduce a widget layer on the Desktop with four draggable widgets:
- ClockWidget: live clock with 1s tick using Intl.DateTimeFormat
- CalendarWidget: interactive month grid with navigation (uses existing createCalendar)
- WeatherWidget: current weather from wttr.in with 30min auto-refresh and emoji mapping
- YouTubeWidget: embedded YouTube player with a generic public video

Shared infrastructure includes a base StyledWidget styled-component with backdrop blur/border/shadow, and a useDraggableWidget hook that supports mouse-based drag constrained within the viewport (respecting TASKBAR_HEIGHT).

A WidgetManager component orchestrates all widgets and is rendered inside the Desktop component after the FileManager.